### PR TITLE
Make core assembly build regardless of the current build configuration

### DIFF
--- a/Emux.GameBoy/Emux.GameBoy.csproj
+++ b/Emux.GameBoy/Emux.GameBoy.csproj
@@ -4,8 +4,6 @@
         <Title>Emux.GameBoy</Title>
         <Version>0.1.0.0</Version>
         <Description>GameBoy emulator engine</Description>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
     <ItemGroup>

--- a/Emux.GameBoy/Emux.GameBoy.csproj
+++ b/Emux.GameBoy/Emux.GameBoy.csproj
@@ -7,9 +7,6 @@
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
     <ItemGroup>
-      <Folder Include="Properties\" />
-    </ItemGroup>
-    <ItemGroup>
       <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
# Summary
- This should allow the core assembly project (`Emux.GameBoy`) to be built regardless of the current solution build configuration by setting the `<AllowUnsafeBlocks>` property globally in the csproj.
	(building in release config previously failed due to the unsafe code switch being present only for the debug configuration)
- This also removes remnants of the project migration from .NET Framework -> .NET Standard (see 81f0a31)