### PR TITLE
Fixed external RAM being dead slow

### DIFF
--- a/Emux.GameBoy/Cartridge/BufferedExternalMemory.cs
+++ b/Emux.GameBoy/Cartridge/BufferedExternalMemory.cs
@@ -55,17 +55,21 @@ namespace Emux.GameBoy.Cartridge
 
 		public byte ReadByte(int address)
 		{
-			return IsActive ? _externalMemory[address] : (byte)0;
+			if (_externalMemory != null && IsActive)
+				return _externalMemory[address];
+
+			return 0;
 		}
 
 		public void ReadBytes(int address, byte[] buffer, int offset, int length)
 		{
-			Array.Copy(_externalMemory, address, buffer, 0, length);
+			if (_externalMemory != null)
+				Array.Copy(_externalMemory, address, buffer, 0, length);
 		}
 
 		public void WriteByte(int address, byte value)
 		{
-			if (IsActive)
+			if (_externalMemory != null && IsActive)
 				_externalMemory[address] = value;
 		}
 

--- a/Emux.GameBoy/Cartridge/BufferedExternalMemory.cs
+++ b/Emux.GameBoy/Cartridge/BufferedExternalMemory.cs
@@ -58,6 +58,9 @@ namespace Emux.GameBoy.Cartridge
 
 		public void ReadBytes(int address, byte[] buffer, int offset, int length)
 		{
+			if (memoryStream == null)
+				return;
+
 			memoryStream.Position = address;
 			memoryStream.Read(buffer, offset, length);
 		}

--- a/Emux.GameBoy/Cartridge/BufferedExternalMemory.cs
+++ b/Emux.GameBoy/Cartridge/BufferedExternalMemory.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Emux.GameBoy.Cartridge {
+	public class BufferedExternalMemory : IExternalMemory {
+		private Stream memoryStream, fileStream;
+
+		public BufferedExternalMemory(string filePath) : this(File.Open(filePath, FileMode.OpenOrCreate))
+		{ }
+
+		public BufferedExternalMemory(Stream filestream)
+		{
+			fileStream = filestream;
+
+			memoryStream = new MemoryStream();
+
+			fileStream.CopyTo(memoryStream);
+		}
+
+		public bool IsActive
+		{
+			get;
+			private set;
+		}
+
+		public void Activate()
+		{
+			IsActive = true;
+		}
+
+		public void Deactivate()
+		{
+			memoryStream?.Flush();
+			IsActive = false;
+		}
+
+		public void SetBufferSize(int length)
+		{
+			memoryStream?.SetLength(length);
+		}
+
+		public byte ReadByte(int address)
+		{
+			if (memoryStream == null)
+				return 0;
+
+			if (IsActive)
+			{
+				memoryStream.Position = address;
+				return (byte)memoryStream.ReadByte();
+			}
+			return 0;
+		}
+
+		public void ReadBytes(int address, byte[] buffer, int offset, int length)
+		{
+			memoryStream.Position = address;
+			memoryStream.Read(buffer, offset, length);
+		}
+
+		public void WriteByte(int address, byte value)
+		{
+			if (memoryStream == null)
+				return;
+
+			if (IsActive)
+			{
+				memoryStream.Position = address;
+				memoryStream.WriteByte(value);
+			}
+		}
+
+		public void Dispose()
+		{
+			var ms = memoryStream;
+			var fs = fileStream;
+
+			memoryStream = null;
+			fileStream = null;
+
+			ms.Position = 0;
+			fs.Position = 0;
+			ms?.Flush();
+			ms?.CopyTo(fs);
+			ms?.Close();
+			ms?.Dispose();
+			fs?.Flush();
+			fs?.Close();
+			fs?.Dispose();
+		}
+	}
+}

--- a/Emux.GameBoy/Cartridge/BufferedExternalMemory.cs
+++ b/Emux.GameBoy/Cartridge/BufferedExternalMemory.cs
@@ -3,20 +3,22 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
-namespace Emux.GameBoy.Cartridge {
-	public class BufferedExternalMemory : IExternalMemory {
+namespace Emux.GameBoy.Cartridge 
+{
+	public class BufferedExternalMemory : IExternalMemory 
+	{
 		private Stream memoryStream, fileStream;
 
 		public BufferedExternalMemory(string filePath) : this(File.Open(filePath, FileMode.OpenOrCreate))
 		{ }
 
-		public BufferedExternalMemory(Stream filestream)
+		public BufferedExternalMemory(Stream fileStream)
 		{
-			fileStream = filestream;
+			this.fileStream = fileStream;
 
 			memoryStream = new MemoryStream();
 
-			fileStream.CopyTo(memoryStream);
+			this.fileStream.CopyTo(memoryStream);
 		}
 
 		public bool IsActive
@@ -74,6 +76,9 @@ namespace Emux.GameBoy.Cartridge {
 
 		public void Dispose()
 		{
+			if (memoryStream == null || fileStream == null) // Already disposed
+				return;
+
 			var ms = memoryStream;
 			var fs = fileStream;
 
@@ -82,13 +87,13 @@ namespace Emux.GameBoy.Cartridge {
 
 			ms.Position = 0;
 			fs.Position = 0;
-			ms?.Flush();
-			ms?.CopyTo(fs);
-			ms?.Close();
-			ms?.Dispose();
-			fs?.Flush();
-			fs?.Close();
-			fs?.Dispose();
+			ms.Flush();
+			ms.CopyTo(fs);
+			ms.Close();
+			ms.Dispose();
+			fs.Flush();
+			fs.Close();
+			fs.Dispose();
 		}
 	}
 }

--- a/Emux.GameBoy/Cartridge/IExternalMemory.cs
+++ b/Emux.GameBoy/Cartridge/IExternalMemory.cs
@@ -1,7 +1,8 @@
-﻿namespace Emux.GameBoy.Cartridge
+﻿using System;
+
+namespace Emux.GameBoy.Cartridge
 {
-    public interface IExternalMemory
-    {
+    public interface IExternalMemory : IDisposable {
         bool IsActive
         {
             get;

--- a/Emux.GameBoy/Cartridge/StreamedExternalMemory.cs
+++ b/Emux.GameBoy/Cartridge/StreamedExternalMemory.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Emux.GameBoy.Cartridge
 {
-    public class StreamedExternalMemory : IExternalMemory, IDisposable
+    public class StreamedExternalMemory : IExternalMemory
     {
         public StreamedExternalMemory(Stream baseStream)
         {
@@ -68,6 +68,8 @@ namespace Emux.GameBoy.Cartridge
 
         public void Dispose()
         {
+			BaseStream.Flush();
+			BaseStream.Close();
             BaseStream.Dispose();
         }
     }

--- a/Emux.MonoGame/Program.cs
+++ b/Emux.MonoGame/Program.cs
@@ -18,23 +18,23 @@ namespace Emux.MonoGame
             (string romFile, string saveFile) = ParseArguments(args);
             var settings = ReadSettings();
 
-            using (var host = new EmuxHost(settings))
-            using (var saveFs = File.Open(saveFile, FileMode.OpenOrCreate))
-            {
-                var cartridge = new EmulatedCartridge(File.ReadAllBytes(romFile), new StreamedExternalMemory(saveFs));
-                var device = new GameBoy.GameBoy(cartridge, host, true);
-                host.GameBoy = device;
-                
-                device.Gpu.VideoOutput = host;
-                
-                var mixer = new GameBoyNAudioMixer();
-                mixer.Connect(device.Spu);
-                var player = new DirectSoundOut();
-                player.Init(mixer);
-                player.Play();
-                
-                host.Run();
-            }
+			using (var host = new EmuxHost(settings))
+			using (var mbc = new BufferedExternalMemory(saveFile))
+			{
+				var cartridge = new EmulatedCartridge(File.ReadAllBytes(romFile), mbc);
+				var device = new GameBoy.GameBoy(cartridge, host, true);
+				host.GameBoy = device;
+
+				device.Gpu.VideoOutput = host;
+
+				var mixer = new GameBoyNAudioMixer();
+				mixer.Connect(device.Spu);
+				var player = new DirectSoundOut();
+				player.Init(mixer);
+				player.Play();
+
+				host.Run();
+			}
         }
 
         private static void PrintAbout()

--- a/Emux/DeviceManager.cs
+++ b/Emux/DeviceManager.cs
@@ -17,7 +17,7 @@ namespace Emux
         public event EventHandler DeviceChanged;
 
         private GameBoy.GameBoy _currentDevice;
-        private StreamedExternalMemory _currentExternalMemory;
+        private IExternalMemory _currentExternalMemory;
 
         public DeviceManager()
         {
@@ -80,7 +80,8 @@ namespace Emux
         public void LoadDevice(string romFilePath, string ramFilePath)
         {
             UnloadDevice();
-            _currentExternalMemory = new StreamedExternalMemory(File.Open(ramFilePath, FileMode.OpenOrCreate));
+
+            _currentExternalMemory = new BufferedExternalMemory(ramFilePath);
             var cartridge = new EmulatedCartridge(File.ReadAllBytes(romFilePath), _currentExternalMemory);
             _currentExternalMemory.SetBufferSize(cartridge.ExternalRamSize);
             CurrentDevice = new GameBoy.GameBoy(cartridge, new WinMmTimer(60), !Properties.Settings.Default.ForceOriginalGameBoy);


### PR DESCRIPTION
Noticed that the emulator grinds to a halt when writing to external RAM when running the demo [Cenotaph](http://www.pouet.net/prod.php?which=59139) after the splash screen. This probably wont be noticeable in most games as they usually aren't doing anything else when accessing external RAM and grind anyway.
Nonetheless, now the sav file is buffered into RAM where it is accessed lightning fast then dumped back to disk when closed, files remain open during.