### PR TITLE
Removed console from appearing on startup

### DIFF
--- a/Emux/Emux.csproj
+++ b/Emux/Emux.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{8D23BA7C-0EB8-4C73-BF04-0EDFC0542F17}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <RootNamespace>Emux</RootNamespace>
     <AssemblyName>Emux</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
@@ -35,7 +35,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <StartupObject />
+    <StartupObject>Emux.App</StartupObject>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NAudio, Version=1.9.0.0, Culture=neutral, PublicKeyToken=null">


### PR DESCRIPTION
Set project type to WinExe as its a Dotnet Framework only supports Windows anyway.