### PR TITLE
Add Video Scale option with 1,2,4,8x and Custom options

### DIFF
--- a/Emux/App.config
+++ b/Emux/App.config
@@ -81,6 +81,12 @@
                     <Key>Z</Key>
                 </value>
             </setting>
+            <setting name="VideoWidth" serializeAs="String">
+                <value>320</value>
+            </setting>
+            <setting name="VideoHeight" serializeAs="String">
+                <value>288</value>
+            </setting>
         </Emux.Properties.Settings>
     </userSettings>
 </configuration>

--- a/Emux/EnumDescriptions.cs
+++ b/Emux/EnumDescriptions.cs
@@ -21,6 +21,14 @@ namespace Emux
                 [Stretch.Uniform] = "Uniform",
                 [Stretch.UniformToFill] = "Uniform to fill"
             };
+            Scales = new Dictionary<int, string>
+            {
+                [0] = "Custom",
+                [1] = "1x",
+                [2] = "2x",
+                [4] = "4x",
+                [8] = "8x",
+            };
         }
 
         public Dictionary<BitmapScalingMode, string> BitmapScalingModeItems
@@ -33,6 +41,10 @@ namespace Emux
             get;
         }
 
-        
+        public Dictionary<int, string> Scales
+        {
+            get;
+        }
+
     }
 }

--- a/Emux/Gui/OptionsDialog.xaml
+++ b/Emux/Gui/OptionsDialog.xaml
@@ -1,6 +1,7 @@
 ﻿<Window x:Class="Emux.Gui.OptionsDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Emux.Gui"
@@ -31,10 +32,21 @@
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
-                            <Label Grid.Row="0" Grid.Column="0" Content="Bitmap scaling mode:" Margin="3"/>
+                            <Label Grid.Row="0" Grid.Column="0" Content="Scale:" Margin="3"/>
                             <ComboBox Grid.Row="0" 
+                                      Name="VideoScaleDD"
+                                      Grid.Column="1" 
+                                      ItemsSource="{Binding Source={StaticResource EnumDescriptions}, Path=Scales}"
+                                      DisplayMemberPath="Value"
+                                      SelectedValuePath="Key"
+                                      Margin="3">
+                            </ComboBox>
+
+                            <Label Grid.Row="1" Grid.Column="0" Content="Bitmap scaling mode:" Margin="3"/>
+                            <ComboBox Grid.Row="1" 
                                       Grid.Column="1" 
                                       ItemsSource="{Binding Source={StaticResource EnumDescriptions}, Path=BitmapScalingModeItems}"
                                       DisplayMemberPath="Value"
@@ -42,8 +54,8 @@
                                       SelectedValue="{emux:SettingBinding VideoBitmapScalingMode}"
                                       Margin="3"/>
 
-                            <Label Grid.Row="1" Grid.Column="0" Content="Stretch mode:" Margin="3"/>
-                            <ComboBox Grid.Row="1" 
+                            <Label Grid.Row="2" Grid.Column="0" Content="Stretch mode:" Margin="3"/>
+                            <ComboBox Grid.Row="2" 
                                       Grid.Column="1" 
                                       ItemsSource="{Binding Source={StaticResource EnumDescriptions}, Path=StretchItems}"
                                       DisplayMemberPath="Value"

--- a/Emux/Gui/OptionsDialog.xaml.cs
+++ b/Emux/Gui/OptionsDialog.xaml.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using Emux.GameBoy.Graphics;
+using Emux.Properties;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -16,6 +18,31 @@ namespace Emux.Gui
         public OptionsDialog()
         {
             InitializeComponent();
+
+            UpdateScaleDD();
+            VideoScaleDD.SelectionChanged += VideoScale_SelectionChanged;
+        }
+
+        private void UpdateScaleDD()
+        {
+            var configWidth = Settings.Default.VideoWidth;
+            var configHeight = Settings.Default.VideoHeight;
+            var widthScale = configWidth / (float)GameBoyGpu.FrameWidth;
+            var heightScale = configHeight / (float)GameBoyGpu.FrameHeight;
+            if (widthScale == heightScale && widthScale % 1 == 0 && heightScale % 1 == 0) // Exact scale
+                VideoScaleDD.SelectedIndex = (int)widthScale;
+            else
+                VideoScaleDD.SelectedIndex = 0;
+        }
+
+        private void VideoScale_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var newScale = VideoScaleDD.SelectedIndex;
+            if (newScale == 0)
+                return;
+
+            Settings.Default.VideoWidth = GameBoyGpu.FrameWidth * newScale;
+            Settings.Default.VideoHeight = GameBoyGpu.FrameHeight * newScale;
         }
 
         public bool CanClose

--- a/Emux/Gui/VideoWindow.xaml
+++ b/Emux/Gui/VideoWindow.xaml
@@ -4,9 +4,19 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Emux"
+        xmlns:emux="clr-namespace:Emux"
         mc:Ignorable="d"
-        Title="GameBoy Video Output" Height="400" Width="444" KeyDown="VideoWindowOnKeyDown" KeyUp="VideoWindowOnKeyUp" Background="Black" Closing="VideoWindowOnClosing">
+        Title="GameBoy Video Output" 
+        Height="{emux:SettingBinding VideoHeight}"
+        Width="{emux:SettingBinding VideoWidth}"
+        KeyDown="VideoWindowOnKeyDown"
+        KeyUp="VideoWindowOnKeyUp" 
+        Background="Black" 
+        Closing="VideoWindowOnClosing">
     <Grid>
-        <Image x:Name="VideoImage" RenderOptions.BitmapScalingMode="{local:SettingBinding VideoBitmapScalingMode}" Stretch="{local:SettingBinding VideoStretchMode}" />
+        <Image 
+            x:Name="VideoImage" 
+            RenderOptions.BitmapScalingMode="{local:SettingBinding VideoBitmapScalingMode}"
+            Stretch="{local:SettingBinding VideoStretchMode}" />
     </Grid>
 </Window>

--- a/Emux/Properties/Settings.Designer.cs
+++ b/Emux/Properties/Settings.Designer.cs
@@ -211,5 +211,29 @@ namespace Emux.Properties {
                 this["KeyBindingB"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("320")]
+        public int VideoWidth {
+            get {
+                return ((int)(this["VideoWidth"]));
+            }
+            set {
+                this["VideoWidth"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("288")]
+        public int VideoHeight {
+            get {
+                return ((int)(this["VideoHeight"]));
+            }
+            set {
+                this["VideoHeight"] = value;
+            }
+        }
     }
 }

--- a/Emux/Properties/Settings.settings
+++ b/Emux/Properties/Settings.settings
@@ -58,5 +58,11 @@
       <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
 &lt;Key&gt;Z&lt;/Key&gt;</Value>
     </Setting>
+    <Setting Name="VideoWidth" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">320</Value>
+    </Setting>
+    <Setting Name="VideoHeight" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">288</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Would have been a  lot simpler to do if there wasn't width AND height, could have just used a IValueConverter and the whole thing could just be a single binding. At least with doing it manually we can support a custom option.
Only issue is, when resizing the window manually, it will still show the last selected option. Just need to call `UpdateScaleDD` on window resize but couldn't figure that out.